### PR TITLE
feat: add language-server-bitbake nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,9 +12,13 @@
         url = "github:anakin4747/wksls";
         inputs.nixpkgs.follows = "nixpkgs";
     };
+    language-server-bitbake = {
+        url = "path:./language-server-bitbake";
+        inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, neovim-nightly-overlay, kconfig-language-server, wksls }:
+  outputs = { self, nixpkgs, neovim-nightly-overlay, kconfig-language-server, wksls, language-server-bitbake }:
     let
       system = "x86_64-linux";
       pkgs = import nixpkgs {
@@ -49,6 +53,7 @@
           gopls
           kconfig-language-server.packages.${system}.default
           wksls.packages.${system}.default
+          language-server-bitbake.packages.${system}.default
           lazygit
           lsof
           lua-language-server

--- a/language-server-bitbake/flake.nix
+++ b/language-server-bitbake/flake.nix
@@ -10,7 +10,6 @@
       system = "x86_64-linux";
       pkgs = import nixpkgs { inherit system; };
 
-      # Build the tree-sitter-bitbake grammar so the server can load its wasm
       tree-sitter-bitbake = pkgs.tree-sitter.buildGrammar {
         language = "bitbake";
         version = "0-unstable";
@@ -18,7 +17,7 @@
           owner = "idillon-sfl";
           repo = "tree-sitter-bitbake";
           rev = "bc577daab90b551ad1dc42c3373db2cb7c43857d";
-          hash = "sha256-zfU3SgsIybD8I/UOxFajyZoaUooK9sVFTplt/enfP7k=";
+          hash = "";
         };
       };
 
@@ -26,7 +25,7 @@
         owner = "yoctoproject";
         repo = "vscode-bitbake";
         rev = "a2fdba8e659778bdbc1f239ac9c6338e54401c60";
-        hash = "sha256-V6kkuSd+CuUkIBH8/7a57t4YmzCPMYDRmwrn934rnHI=";
+        hash = "";
       };
 
       language-server-bitbake = pkgs.buildNpmPackage {
@@ -35,7 +34,7 @@
 
         src = vscode-bitbake-src;
 
-        npmDepsHash = "sha256-j1awkWOh+xuGzNdBra+QI6anpCVmD/YRYe3fzXRFYtY=";
+        npmDepsHash = "";
 
         makeCacheWritable = true;
 
@@ -48,15 +47,12 @@
         installPhase = ''
           mkdir -p $out/bin $out/lib/language-server-bitbake
 
-          # Copy compiled server
           cp -r server/out $out/lib/language-server-bitbake/out
           cp -r server/node_modules $out/lib/language-server-bitbake/node_modules
 
-          # Provide wasm files from nix-built grammars
           cp ${tree-sitter-bitbake}/parser $out/lib/language-server-bitbake/tree-sitter-bitbake.wasm
           cp ${pkgs.tree-sitter-grammars.tree-sitter-bash}/parser $out/lib/language-server-bitbake/tree-sitter-bash.wasm
 
-          # Wrapper script
           cat > $out/bin/language-server-bitbake <<EOF
           #!${pkgs.nodejs}/bin/node
           require('$out/lib/language-server-bitbake/out/server.js');

--- a/language-server-bitbake/flake.nix
+++ b/language-server-bitbake/flake.nix
@@ -1,0 +1,73 @@
+{
+  description = "language-server-bitbake from the vscode-bitbake extension";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+
+      # Build the tree-sitter-bitbake grammar so the server can load its wasm
+      tree-sitter-bitbake = pkgs.tree-sitter.buildGrammar {
+        language = "bitbake";
+        version = "0-unstable";
+        src = pkgs.fetchFromGitHub {
+          owner = "idillon-sfl";
+          repo = "tree-sitter-bitbake";
+          rev = "bc577daab90b551ad1dc42c3373db2cb7c43857d";
+          hash = "sha256-zfU3SgsIybD8I/UOxFajyZoaUooK9sVFTplt/enfP7k=";
+        };
+      };
+
+      vscode-bitbake-src = pkgs.fetchFromGitHub {
+        owner = "yoctoproject";
+        repo = "vscode-bitbake";
+        rev = "a2fdba8e659778bdbc1f239ac9c6338e54401c60";
+        hash = "sha256-V6kkuSd+CuUkIBH8/7a57t4YmzCPMYDRmwrn934rnHI=";
+      };
+
+      language-server-bitbake = pkgs.buildNpmPackage {
+        pname = "language-server-bitbake";
+        version = "2.8.0";
+
+        src = vscode-bitbake-src;
+
+        npmDepsHash = "sha256-j1awkWOh+xuGzNdBra+QI6anpCVmD/YRYe3fzXRFYtY=";
+
+        makeCacheWritable = true;
+
+        nativeBuildInputs = with pkgs; [ typescript ];
+
+        buildPhase = ''
+          npm run compile
+        '';
+
+        installPhase = ''
+          mkdir -p $out/bin $out/lib/language-server-bitbake
+
+          # Copy compiled server
+          cp -r server/out $out/lib/language-server-bitbake/out
+          cp -r server/node_modules $out/lib/language-server-bitbake/node_modules
+
+          # Provide wasm files from nix-built grammars
+          cp ${tree-sitter-bitbake}/parser $out/lib/language-server-bitbake/tree-sitter-bitbake.wasm
+          cp ${pkgs.tree-sitter-grammars.tree-sitter-bash}/parser $out/lib/language-server-bitbake/tree-sitter-bash.wasm
+
+          # Wrapper script
+          cat > $out/bin/language-server-bitbake <<EOF
+          #!${pkgs.nodejs}/bin/node
+          require('$out/lib/language-server-bitbake/out/server.js');
+          EOF
+          chmod +x $out/bin/language-server-bitbake
+        '';
+      };
+    in {
+      packages.${system} = {
+        inherit language-server-bitbake;
+        default = language-server-bitbake;
+      };
+    };
+}


### PR DESCRIPTION
Adds a standalone Nix flake at `language-server-bitbake/flake.nix` that packages `language-server-bitbake` from the [yoctoproject/vscode-bitbake](https://github.com/yoctoproject/vscode-bitbake) monorepo.

## Structure

- `language-server-bitbake/flake.nix` — self-contained flake that builds the TypeScript server, the `tree-sitter-bitbake` grammar wasm, and installs a `language-server-bitbake` binary
- `flake.nix` — adds the sub-flake as a path input and includes the package in the environment

## Hashes

All three hashes (`tree-sitter-bitbake` src, `vscode-bitbake` src, `npmDepsHash`) are left empty so nix will report the correct value for each on first build. Run `nix build .#language-server-bitbake` and fill them in from the error output one at a time.