### PR TITLE
feat: enable vim._core.ui2 for all targets except cmdline

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -2,6 +2,8 @@
 vim.g.mapleader = ' '
 vim.g.loaded_netrwPlugin = 1
 
+require('vim._core.ui2').enable({})
+
 -- options {{{
 local options = {
     backup = false,


### PR DESCRIPTION
Enables Neovim's new UI (ui2) with `targets = 'msg'` so messages go to the ephemeral message window. Cmdline is left as-is.