### PR TITLE
feat: disable ui2 for cmdline, route messages to msg window

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -2,7 +2,11 @@
 vim.g.mapleader = ' '
 vim.g.loaded_netrwPlugin = 1
 
-require('vim._core.ui2').enable({})
+require('vim._core.ui2').enable({
+    msg = {
+        targets = 'msg',
+    },
+})
 
 -- options {{{
 local options = {


### PR DESCRIPTION
Sets `targets = 'msg'` so ui2 handles messages in the ephemeral message window but leaves the cmdline unchanged.